### PR TITLE
Modified Server for injectable adapter and better testability

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,26 +3,33 @@
 
 var debug = require('debug')('irc-server');
 var net = require('net');
+var Q = require('q');
 var Client = require('./client');
-var GitterAdapter = require('./gitter-adapter');
 var dashboard = require('../dashboard');
 
 // The server handles incoming TCP connections and
 // instantiates a Client to handle each connection
-function Server() {
+function Server(adapter) {
   this.clients = {};
+  this.adapter = adapter;
 }
 
 Server.prototype.start = function(ports) {
+  var deferred = Q.defer();
+
   var server = net.createServer(this.connectionListener.bind(this));
   server.listen(ports.irc, function() {
     debug('IRC server listening on ' + ports.irc);
-  });
+
+    deferred.resolve(server);
+  }.bind(this));
 
   dashboard(this, ports.web);
 
   process.on('SIGTERM', this.stop.bind(this));
   process.on('SIGINT',  this.stop.bind(this));
+
+  return deferred.promise;
 };
 
 Server.prototype.stop = function() {
@@ -48,7 +55,7 @@ Server.prototype.stop = function() {
 Server.prototype.connectionListener = function(conn) {
 
   var client  = new Client(conn);
-  var adapter = new GitterAdapter(client);
+  var adapter = this.adapter.call(Object.create(this.adapter.prototype), client);
 
   debug('Client connected ' + client.uuid);
   this.clients[client.uuid] = client; 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "jade": "^1.9.2",
     "memwatch": "^0.2.2",
     "node-gitter": "^1.2.7",
+    "q": "^1.2.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {
+    "csprng": "^0.1.1",
     "sinon": "^1.12.2"
   }
 }

--- a/runner.js
+++ b/runner.js
@@ -6,10 +6,11 @@ var WEBPORT = process.env.WEBPORT || 4567;
 
 var memwatch = require('memwatch');
 var Server   = require('./lib/server');
+var GitterAdapter = require('./lib/gitter-adapter');
 
 memwatch.on('leak', function(info) {
   console.log('[memwatch]', info.growth, info.reason);
 });
 
-var server = new Server();
+var server = new Server(GitterAdapter);
 server.start({irc: IRCPORT, web: WEBPORT});

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -1,18 +1,42 @@
-var assert  = require('assert');
-var net     = require('net');
+var assert      = require('assert'),
+    net         = require('net'),
+    sinon       = require('sinon'),
+    Server      = require('../lib/server.js'),
+    TestAdapter = require('./test-adapter.js');
 
-var Server = require('../lib/server.js');
+var IRCPORT = 9876,
+    WEBPORT = 5432;
 
-var IRCPORT = 9876;
-var WEBPORT = 5432;
+describe('Server', function () {
+  var server, _instance;
 
-describe('Server', function(){
-  it('should allow incoming connections on a given port', function(done) {
-    var server = new Server();
-    server.start({irc: IRCPORT, web: WEBPORT});
+  before(function (done) {
+    server = new Server(TestAdapter);
+    server.start({irc: IRCPORT, web: WEBPORT})
+        .then(function (instance) {
+          _instance = instance;
+          done();
+        });
+  });
 
-    var client = net.connect({port: IRCPORT});
-    client.on('end', done);
-    client.end();
+  after(function (done) {
+    if (_instance) _instance.close();
+    done();
+  });
+
+  it('should allow incoming connections on a given port', function (done) {
+    var client = net.connect({port: IRCPORT}, function () {
+      setTimeout(function () {
+        var connectedClients = Object.keys(server.clients).length;
+        assert.equal(connectedClients, 1, 'Expected a single connected client');
+
+        client.end();
+      }, 0);
+    });
+
+    client.on('end', function () {
+      done();
+    });
   });
 });
+

--- a/test/test-adapter.js
+++ b/test/test-adapter.js
@@ -1,0 +1,35 @@
+'use strict';
+
+function empty() {
+}
+
+function Adapter(client) {
+  this.client = client;
+
+  // Keep track of the active rooms
+  this.rooms = {};
+
+  var commands = {
+    PASS   : empty,
+    PRIVMSG: empty,
+    QUIT   : empty,
+    NICK   : empty,
+    USER   : empty,
+    JOIN   : empty,
+    PART   : empty,
+    WHO    : empty,
+    LIST   : empty,
+    MOTD   : empty
+  };
+
+  Object.keys(commands).map(function (cmd) {
+    this.client.on(cmd, commands[cmd].bind(this));
+  }.bind(this));
+
+  this.init();
+}
+
+Adapter.prototype.init = function () {
+};
+
+module.exports = Adapter;


### PR DESCRIPTION
I made some modifications to the Server object to allow for injecting adapters. I changed the one test in `server_test.js` to assert on a single connected client. To make the tests repeatable, I had to expose the net.Server object from within `Server` so it could get closed down after the test suite ran.

I was going to add a test for the injectable adapter, but I'm not sure of the best way to go about this since `adapter` isn't stored on client. I'd imagine `Client` is the meant to be actual bridge (socket+Adapter) and it would be safe and intuitive to add the Adapter to the instance. This would also allow for cleanup of the adapter in the `client#disconnected`  callback of `Server#connectionListener`. I could be missing something, but don't the adapters currently create a memory leak in `gitter-adapter.js`?  `subscribeToRoom` takes a room object onto which multiple events are bound with functions bound to the instance of the adapter.  Setting the adapter to null in connectionListener doesn't remove listeners on the adapter from those room events.  I'd expect messages after a client disconnects to continue being processed and this will throw an object is undefined exception:

```
// gitter-adapter.js line 112
c.send(mask, 'PRIVMSG', '#' + room.uri, ':' + text);
```

I could go about fixing these things, I just wanted to open a discussion to make sure I wasn't wrong since I don't have a local gitter server that I can test the assumptions against.