### PR TITLE
Fix replies

### DIFF
--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -175,7 +175,7 @@ Adapter.prototype.register = function(username, hostname, servername, realname) 
   c.send(c.host, irc.reply.welcome, c.nick, 'Gitter', c.mask());
   c.send(c.host, irc.reply.yourHost, c.nick, 'Version:', VERSION);
   c.send(c.host, irc.reply.created, c.nick, 'Created on', DATE);
-  c.send(c.host, irc.reply.myInfo, c.hostname, VERSION, 'wo', 'ntr');
+  c.send(c.host, irc.reply.myInfo, c.nick, c.hostname, VERSION, 'wo', 'ntr');
   this.messageOfTheDay();
 };
 
@@ -208,7 +208,7 @@ Adapter.prototype.joinRoom = function(channel) {
   })
   .then(this.subscribeToRoom.bind(this))
   .catch(function(err) {
-    c.send(c.host, irc.errors.noSuchChannel, ': Invalid channel or insufficient permissions');
+    c.send(c.host, irc.errors.noSuchChannel, c.nick, ':Invalid channel or insufficient permissions');
     log('Error joining room ', uri, err);
     log(err.stack);
   });


### PR DESCRIPTION
Hi,
I've managed to find and fix two trivial protocol issues in the adapter.

All RPL_ and ERR_ responses must include the user's nickname as the first parameter.