### PR TITLE
Using Halley instead of Faye for irc-bridge

### DIFF
--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -7,6 +7,7 @@ var Gitter    = require('node-gitter');
 var manifest  = require('../package.json');
 var VERSION   = manifest.version;
 var DATE      = Date();
+var Promise   = require('bluebird');
 
 var log = console.log;
 
@@ -50,8 +51,8 @@ Adapter.prototype.listenForOneToOnes = function() {
       if (!room.oneToOne) return;
       var nick = room.user.username;
       var mask = ':' + nick + '!' + nick + '@irc.gitter.im';
-      msg.text.split('\n').forEach(function(line) { 
-        c.send(mask, 'PRIVMSG', c.nick, ':' + line); 
+      msg.text.split('\n').forEach(function(line) {
+        c.send(mask, 'PRIVMSG', c.nick, ':' + line);
       });
       if (msg.chatId) this.user.markAsRead(room.id, [msg.chatId]);
       c.trackEvent('1-to-1-from-faye');
@@ -247,7 +248,7 @@ Adapter.prototype.listUsers = function(channel, key) {
     });
     c.send(c.host, irc.reply.who, c.nick, channel, 'gitter', c.host, c.hostname, 'gitter', 'H', ':0', 'Gitter Bot');
     c.send(c.host, irc.reply.endWho, c.nick, channel, ':End of /WHO list.');
-  })  
+  })
   .catch(function(err) {
     log('Error listing users for ', uri, err);
     log(err.stack);
@@ -289,17 +290,33 @@ Adapter.prototype.quit = function() {
 };
 
 Adapter.prototype._unsubscribe = function(uri) {
-  if (!this.rooms[uri]) return;
+  var room = this.rooms[uri];
+  if (!room) return;
 
-  this.rooms[uri].unsubscribe();
-  this.rooms[uri].removeAllListeners();
+  room.removeAllListeners();
   delete this.rooms[uri];
+
+  return room.unsubscribe();
 };
 
 Adapter.prototype._teardown = function() {
-  if (this.oneToOneSub) this.oneToOneSub.cancel();
-  Object.keys(this.rooms).map(this._unsubscribe.bind(this));
-  if (this.gitterClient) this.gitterClient.faye.client.disconnect();
+  var unsubscribes = [];
+
+  if (this.oneToOneSub) unsubscribes.push([this.oneToOneSub.unsubscribe()]);
+
+  unsubscribes = unsubscribes.concat(Object.keys(this.rooms).map(this._unsubscribe.bind(this)));
+
+  return Promise.all(unsubscribes)
+    .bind(this)
+    .catch(function(err) {
+      log('Unable to unsubscribe', err);
+    })
+    .then(function() {
+      if (this.gitterClient) this.gitterClient.faye.disconnect();
+      this.gitterClient = null; 
+    })
+  ;
+
 };
 
 module.exports = Adapter;

--- a/lib/server.js
+++ b/lib/server.js
@@ -69,5 +69,5 @@ Server.prototype.exit = function() {
     process.exit(err ? 1 : 0);
   });
 };
-    
+
 module.exports = Server;

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
   "author": "The Gitter Team",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.1.1",
     "carrier": "^0.1.14",
     "debug": "^2.1.1",
     "eventemitter3": "^0.1.6",
     "express": "^4.12.0",
     "irc-message": "^2.0.1",
     "jade": "^1.9.2",
-    "node-gitter": "^1.2.8",
+    "node-gitter": "^2.0.1",
     "uuid": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR uses a newer (beta) version of node-gitter which uses Halley instead of Faye.