### PR TITLE
Fix splitting of long messages that have colons in the body

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -112,16 +112,16 @@ Client.prototype.send = function() {
   // Respect IRC line length limit of 512 chars
   // https://tools.ietf.org/html/rfc2812#section-2.3
   if (message.length > 512) {
-    var parts   = message.split(':');
-    var command = parts[1];
-    var payload = parts[2];
+    var payload_marker  = message.indexOf(' :');
+    var command = message.substr(0, payload_marker);
+    var payload = message.substr(payload_marker + 2);
 
     var chunks = payload.split(' ');
     var chunk = [];
     var _chunk;
     while (chunks.length) {
       chunk.push(chunks.shift());
-       _chunk = ':' + command + ':' + chunk.join(' ') + '\r\n';
+       _chunk = command + ' :' + chunk.join(' ') + '\r\n';
       if (_chunk.length > 450 || !chunks.length) {
         debug('Tx: ' + _chunk);
         this.socket.write(_chunk);

--- a/lib/client.js
+++ b/lib/client.js
@@ -121,10 +121,17 @@ Client.prototype.send = function() {
     var _chunk;
     while (chunks.length) {
       chunk.push(chunks.shift());
-       _chunk = command + ' :' + chunk.join(' ') + '\r\n';
+      _chunk = command + ' :' + chunk.join(' ');
       if (_chunk.length > 450 || !chunks.length) {
+
+        // handle long words with no spaces
+        if (_chunk.length > 510) {
+          // re-add what didn't fit to the start of chunks
+          chunks.splice(0, 0, _chunk.substr(510));
+          _chunk = _chunk.substr(0, 510);
+        }
         debug('Tx: ' + _chunk);
-        this.socket.write(_chunk);
+        this.socket.write(_chunk + '\r\n');
         chunk = []; // start another chunk
       }
     }

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -69,4 +69,25 @@ describe('Client', function(){
     sinon.assert.calledTwice(spy);
   });
 
+  it('should split long messages', function(done) {
+    var socket = new net.Socket();
+
+    var prefixes = ':source PRIVMSG target :';
+    var message_index = 0;
+    var messages = [
+      'first message: ' + Array(450).join('a'),
+      'second message ' + Array(100).join('a')
+    ]
+
+    var stub = sinon.stub(socket, 'write', function(msg) {
+      assert.equal(msg, prefixes + messages[message_index++] + "\r\n");
+      if (message_index == 2) {
+        done();
+      }
+    });
+
+    var client = new Client(socket);
+    client.send(':source', 'PRIVMSG', 'target', ':' + messages.join(' '));
+  });
+
 });

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -73,21 +73,26 @@ describe('Client', function(){
     var socket = new net.Socket();
 
     var prefixes = ':source PRIVMSG target :';
+    var prefix_len = prefixes.length;
     var message_index = 0;
     var messages = [
-      'first message: ' + Array(450).join('a'),
-      'second message ' + Array(100).join('a')
+      // two messages with normal-ish spacing and colons
+      'first message: ' + Array(450).join('a') + ' ',
+      'second message ' + Array(450).join('a') + ' ',
+      // two messages with one long word with no spaces
+      Array(510 - prefix_len + 1).join('a'),
+      Array(510 - prefix_len + 1).join('a')
     ]
 
     var stub = sinon.stub(socket, 'write', function(msg) {
-      assert.equal(msg, prefixes + messages[message_index++] + "\r\n");
-      if (message_index == 2) {
+      assert.equal(msg, prefixes + messages[message_index++].trim() + "\r\n");
+      if (message_index == messages.length) {
         done();
       }
     });
 
     var client = new Client(socket);
-    client.send(':source', 'PRIVMSG', 'target', ':' + messages.join(' '));
+    client.send(':source', 'PRIVMSG', 'target', ':' + messages.join(''));
   });
 
 });


### PR DESCRIPTION
The original code tried to split by ':' and picked parts 1 and 2,
ignoring anything after that. Now it uses indexOf() and substr()