### PR TITLE
MOTD messages must be prefixed with colon

### DIFF
--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -329,9 +329,9 @@ Adapter.prototype.messageOfTheDay = function() {
   var c = this.client;
 
   c.send(c.host, irc.reply.motdStart, c.nick, ':- Message of the Day -');
-  c.send(c.host, irc.reply.motd,      c.nick, 'Welcome To Gitter IRC!');
-  c.send(c.host, irc.reply.motd,      c.nick, 'Info at https://irc.gitter.im');
-  c.send(c.host, irc.reply.motd,      c.nick, 'Code at https://github.com/gitterHQ/irc-bridge');
+  c.send(c.host, irc.reply.motd,      c.nick, ':- Welcome To Gitter IRC!');
+  c.send(c.host, irc.reply.motd,      c.nick, ':- Info at https://irc.gitter.im');
+  c.send(c.host, irc.reply.motd,      c.nick, ':- Code at https://github.com/gitterHQ/irc-bridge');
   c.send(c.host, irc.reply.motdEnd,   c.nick, ':End of /MOTD command.');
 };
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc2812#page-48