### PR TITLE
Ignore repeated JOIN attempts to a channel

### DIFF
--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -140,13 +140,9 @@ Adapter.prototype.setup = function(token) {
 Adapter.prototype.subscribeToRoom = function(room) {
   var self = this;
   var c = this.client;
-  var uri = (room.uri || room.name).toLowerCase();
 
-  debug('Subscribing to room ' + uri, { token: this.loggableToken});
+  debug('Subscribing to room ' + room.uri, { token: this.loggableToken});
 
-  if (this.rooms[uri]) return;
-
-  this.rooms[uri] = room;
   room.subscribe();
 
   room.on('chatMessages', function(evt) {
@@ -251,6 +247,11 @@ Adapter.prototype.joinRoomFromChannel = function(channel) {
 
 Adapter.prototype.joinRoom = function(room) {
   var c = this.client;
+  var uri = room.uri.toLowerCase();
+
+  if (this.rooms[uri]) return;
+
+  this.rooms[uri] = room;
   
   room.users()
     .then(function(users) {


### PR DESCRIPTION
This moves the `this.rooms[uri]` check from subscribeToRoom to joinRoom,
so that it happens before the JOIN/NAMES replies are sent to the client.

This fixes some recent issues with the server-side autojoin and pidgin
(which sends its own set of JOIN on connection of all open windows)

Ref #62 