### PR TITLE
Fix splitting of long messages

### DIFF
--- a/lib/chunk-string.js
+++ b/lib/chunk-string.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var chunkString = function(str, size) {
+  var chunks = [];
+  var spacePieces = str.split(' ');
+  return spacePieces.reduce(function(chunks, piece, index) {
+    var isFirstPiece = index === 0;
+    var isLastPiece = index === spacePieces.length - 1;
+
+    var chunkSeparator = isFirstPiece ? '' : ' ';
+    var currentChunk = chunks[chunks.length - 1];
+    // If a piece is simply too long, split it up harshly
+    if(piece.length > size) {
+      // Add whatever we can to the current
+      var startingPieceIndex = size - (chunkSeparator + currentChunk).length;
+      currentChunk += chunkSeparator + piece.substring(0, startingPieceIndex);
+      chunks[chunks.length - 1] = currentChunk;
+
+      // Then just add the rest to more chunks
+      var leftover = piece.substring(startingPieceIndex);
+      for (var i = 0; i < leftover.length; i += size) {
+        chunks.push(leftover.substring(i, i + size));
+      }
+    }
+    // Otherwise try to split nicely at spaces
+    else if((currentChunk + chunkSeparator + piece).length <= size) {
+      currentChunk += chunkSeparator + piece;
+      chunks[chunks.length - 1] = currentChunk;
+    }
+    // If we simply reached max for this chunk, move to the next one
+    else {
+      currentChunk = piece;
+      chunks.push('');
+      chunks[chunks.length - 1] = currentChunk;
+    }
+
+    return chunks;
+  }, ['']);
+};
+
+module.exports = chunkString;

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,6 +8,7 @@ var EventEmitter  = require('eventemitter3');
 var carrier       = require('carrier');
 var ircMessage    = require('irc-message');
 var crypto        = require('crypto');
+var chunkString   = require('./chunk-string');
 
 
 // https://tools.ietf.org/html/rfc2812#section-2.3
@@ -15,43 +16,7 @@ var MESSAGE_MAX_LENGTH = 512;
 // 512 - CR - LF
 var MESSAGE_PIECE_MAX_LENGTH = 510;
 
-var chunkString = function(str, size) {
-  var chunks = [];
-  var spacePieces = str.split(' ');
-  return spacePieces.reduce(function(chunks, piece, index) {
-    var isFirstPiece = index === 0;
-    var isLastPiece = index === spacePieces.length - 1;
 
-    var chunkSeparator = isFirstPiece ? '' : ' ';
-    var currentChunk = chunks[chunks.length - 1];
-    // If a piece is simply too long, split it up harshly
-    if(piece.length > size) {
-      // Add whatever we can to the current
-      var startingPieceIndex = size - (chunkSeparator + currentChunk).length;
-      currentChunk += chunkSeparator + piece.substring(0, startingPieceIndex);
-      chunks[chunks.length - 1] = currentChunk;
-
-      // Then just add the rest to more chunks
-      var leftover = piece.substring(startingPieceIndex);
-      for (var i = 0; i < leftover.length; i += size) {
-        chunks.push(leftover.substring(i, i + size));
-      }
-    }
-    // Otherwise try to split nicely at spaces
-    else if((currentChunk + chunkSeparator + piece).length <= size) {
-      currentChunk += chunkSeparator + piece;
-      chunks[chunks.length - 1] = currentChunk;
-    }
-    // If we simply reached max for this chunk, move to the next one
-    else {
-      currentChunk = piece;
-      chunks.push('');
-      chunks[chunks.length - 1] = currentChunk;
-    }
-
-    return chunks;
-  }, ['']);
-};
 
 
 // The Client handles a single socket client,
@@ -204,5 +169,6 @@ Client.prototype.disconnect = function(opts) {
 
   this.socket.end();
 };
+
 
 module.exports = Client;

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,10 +17,40 @@ var MESSAGE_PIECE_MAX_LENGTH = 510;
 
 var chunkString = function(str, size) {
   var chunks = [];
-  for (var i = 0; i < str.length; i += size) {
-    chunks.push(str.substring(i, i + size));
-  }
-  return chunks;
+  var spacePieces = str.split(' ');
+  return spacePieces.reduce(function(chunks, piece, index) {
+    var isFirstPiece = index === 0;
+    var isLastPiece = index === spacePieces.length - 1;
+
+    var chunkSeparator = isFirstPiece ? '' : ' ';
+    var currentChunk = chunks[chunks.length - 1];
+    // If a piece is simply too long, split it up harshly
+    if(piece.length > size) {
+      // Add whatever we can to the current
+      var startingPieceIndex = size - (chunkSeparator + currentChunk).length;
+      currentChunk += chunkSeparator + piece.substring(0, startingPieceIndex);
+      chunks[chunks.length - 1] = currentChunk;
+
+      // Then just add the rest to more chunks
+      var leftover = piece.substring(startingPieceIndex);
+      for (var i = 0; i < leftover.length; i += size) {
+        chunks.push(leftover.substring(i, i + size));
+      }
+    }
+    // Otherwise try to split nicely at spaces
+    else if((currentChunk + chunkSeparator + piece).length <= size) {
+      currentChunk += chunkSeparator + piece;
+      chunks[chunks.length - 1] = currentChunk;
+    }
+    // If we simply reached max for this chunk, move to the next one
+    else {
+      currentChunk = piece;
+      chunks.push('');
+      chunks[chunks.length - 1] = currentChunk;
+    }
+
+    return chunks;
+  }, ['']);
 };
 
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,21 @@ var carrier       = require('carrier');
 var ircMessage    = require('irc-message');
 var crypto        = require('crypto');
 
+
+// https://tools.ietf.org/html/rfc2812#section-2.3
+var MESSAGE_MAX_LENGTH = 512;
+// 512 - CR - LF
+var MESSAGE_PIECE_MAX_LENGTH = 510;
+
+var chunkString = function(str, size) {
+  var chunks = [];
+  for (var i = 0; i < str.length; i += size) {
+    chunks.push(str.substring(i, i + size));
+  }
+  return chunks;
+};
+
+
 // The Client handles a single socket client,
 // parses each line and emits an event when an
 // IRC command is received.
@@ -109,25 +124,20 @@ Client.prototype.send = function() {
   var args = Array.prototype.slice.call(arguments);
   var message = args.join(' ');
 
-  // Respect IRC line length limit of 512 chars
+  // Respect IRC line length limit of 512 chars (MESSAGE_MAX_LENGTH)
   // https://tools.ietf.org/html/rfc2812#section-2.3
-  if (message.length > 512) {
-    var parts   = message.split(':');
-    var command = parts[1];
-    var payload = parts[2];
+  if (message.length > MESSAGE_PIECE_MAX_LENGTH) {
+    var payload_marker  = message.indexOf(' :');
+    var command = message.substr(0, payload_marker) + ' :';
+    var payload = message.substr(payload_marker + 2);
 
-    var chunks = payload.split(' ');
-    var chunk = [];
-    var _chunk;
-    while (chunks.length) {
-      chunk.push(chunks.shift());
-       _chunk = ':' + command + ':' + chunk.join(' ') + '\r\n';
-      if (_chunk.length > 450 || !chunks.length) {
-        debug('Tx: ' + _chunk);
-        this.socket.write(_chunk);
-        chunk = []; // start another chunk
-      }
-    }
+    var payloadChunks = chunkString(payload, MESSAGE_PIECE_MAX_LENGTH - command.length);
+    payloadChunks.forEach(function(payloadChunk) {
+      var messageChunk = command + payloadChunk;
+      debug('Tx: ' + messageChunk);
+      this.socket.write(messageChunk + '\r\n');
+    }.bind(this));
+
   } else {
     debug('Tx: ' + message);
     this.socket.write(message + '\r\n');

--- a/test/chunk-string_test.js
+++ b/test/chunk-string_test.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+var chunkString = require('../lib/chunk-string');
+
+describe('chunk-string', function() {
+  it('should not mangle anything below the threshold size', function() {
+    assert.deepEqual(chunkString('foo', 4), ['foo']);
+  });
+  it('should split at spaces', function() {
+    assert.deepEqual(chunkString('foo bar', 4), ['foo', 'bar']);
+  });
+  it('should split at spaces with different size pieces', function() {
+    assert.deepEqual(chunkString('foo a bar', 4), ['foo', 'a', 'bar']);
+  });
+  it('should harshly split items that have no spaces', function() {
+    assert.deepEqual(chunkString('foobarbaz', 4), ['foob', 'arba', 'z']);
+  });
+  it('should maintain words under threshold and still split up another piece', function() {
+    assert.deepEqual(chunkString('foo barbazqux', 4), ['foo ', 'barb', 'azqu', 'x']);
+  });
+  it('should split up piece first and maintain words in another piece under threshold', function() {
+    assert.deepEqual(chunkString('barbazqux foo', 4), ['barb', 'azqu', 'x', 'foo']);
+  });
+  it('should merge some space pieces together that fit', function() {
+    assert.deepEqual(chunkString('do foo and bar', 8), ['do foo', 'and bar']);
+  });
+});


### PR DESCRIPTION
Based off of @dequis PR https://github.com/gitterHQ/irc-bridge/pull/61

 - Fixes issue where part of a message is missing if using colons and is a long message.
 - Will split out long messages without spaces into proper 512 chunks (according to IRC spec)

### Todo:

 - [x] Change `MESSAGE_PIECE_MAX_LENGTH` to 450 so that there is a 60 character margin and words don't get cut-off. Thanks @dequis, https://github.com/gitterHQ/irc-bridge/pull/61#discussion_r67290804

---

 - Tested in HexChat