### PR TITLE
Disable autojoin if already joined rooms

### DIFF
--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -140,13 +140,9 @@ Adapter.prototype.setup = function(token) {
 Adapter.prototype.subscribeToRoom = function(room) {
   var self = this;
   var c = this.client;
-  var uri = (room.uri || room.name).toLowerCase();
 
-  debug('Subscribing to room ' + uri, { token: this.loggableToken});
+  debug('Subscribing to room ' + room.uri, { token: this.loggableToken});
 
-  if (this.rooms[uri]) return;
-
-  this.rooms[uri] = room;
   room.subscribe();
 
   room.on('chatMessages', function(evt) {
@@ -251,6 +247,11 @@ Adapter.prototype.joinRoomFromChannel = function(channel) {
 
 Adapter.prototype.joinRoom = function(room) {
   var c = this.client;
+  var uri = room.uri.toLowerCase();
+
+  if (this.rooms[uri]) return;
+
+  this.rooms[uri] = room;
   
   room.users()
     .then(function(users) {

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -10,6 +10,7 @@ var VERSION    = manifest.version;
 var DATE       = Date();
 
 var MARK_AS_READ_DELAY = 1500;
+var AUTOJOIN_DELAY = 1000;
 var AUTOJOIN_LIMIT = 10;
 
 // NOTE: whytf isn't this using debug?
@@ -127,7 +128,15 @@ Adapter.prototype.setup = function(token) {
     this.user = user;
     this.client.authenticate(user);
     this.listenForOneToOnes();
-    this.autoJoin();
+
+    setTimeout(function() {
+      if(Object.keys(this.rooms).length === 0) {
+        this.autoJoin();
+      }
+      else {
+        debug('Not autojoining rooms because they already joined some', { token: this.loggableToken });
+      }
+    }.bind(this), AUTOJOIN_DELAY);
   }.bind(this))
   .catch(function(err) {
     log('Authentication failed for token ', token);
@@ -252,7 +261,7 @@ Adapter.prototype.joinRoom = function(room) {
   if (this.rooms[uri]) return;
 
   this.rooms[uri] = room;
-  
+
   room.users()
     .then(function(users) {
       var _channel = '#' + room.uri;

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -10,7 +10,7 @@ var VERSION    = manifest.version;
 var DATE       = Date();
 
 var MARK_AS_READ_DELAY = 1500;
-var AUTOJOIN_DELAY = 1000;
+var AUTOJOIN_DELAY = 2500;
 var AUTOJOIN_LIMIT = 10;
 
 // NOTE: whytf isn't this using debug?


### PR DESCRIPTION
Addresses concern brought up in another issue about wanting to disable autojoin because they already use the autojoin option in their IRC clients.

 - https://github.com/gitterHQ/irc-bridge/issues/62#issuecomment-225603328
 - https://github.com/gitterHQ/irc-bridge/issues/62#issuecomment-226362003

This PR adds functionality so that our autojoin happens 1 second after connecting but only if they haven't joined other rooms. This delay is plenty of times for clients to have joined rooms in my testing but curious if we need to bump it more.

Tested with HexChat locally.