### PR TITLE
Release/1.2.0

### DIFF
--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -140,13 +140,9 @@ Adapter.prototype.setup = function(token) {
 Adapter.prototype.subscribeToRoom = function(room) {
   var self = this;
   var c = this.client;
-  var uri = (room.uri || room.name).toLowerCase();
 
-  debug('Subscribing to room ' + uri, { token: this.loggableToken});
+  debug('Subscribing to room ' + room.uri, { token: this.loggableToken});
 
-  if (this.rooms[uri]) return;
-
-  this.rooms[uri] = room;
   room.subscribe();
 
   room.on('chatMessages', function(evt) {
@@ -251,6 +247,11 @@ Adapter.prototype.joinRoomFromChannel = function(channel) {
 
 Adapter.prototype.joinRoom = function(room) {
   var c = this.client;
+  var uri = room.uri.toLowerCase();
+
+  if (this.rooms[uri]) return;
+
+  this.rooms[uri] = room;
   
   room.users()
     .then(function(users) {

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -10,6 +10,7 @@ var VERSION    = manifest.version;
 var DATE       = Date();
 
 var MARK_AS_READ_DELAY = 1500;
+var AUTOJOIN_DELAY = 1000;
 var AUTOJOIN_LIMIT = 10;
 
 // NOTE: whytf isn't this using debug?
@@ -127,7 +128,15 @@ Adapter.prototype.setup = function(token) {
     this.user = user;
     this.client.authenticate(user);
     this.listenForOneToOnes();
-    this.autoJoin();
+
+    setTimeout(function() {
+      if(Object.keys(this.rooms).length === 0) {
+        this.autoJoin();
+      }
+      else {
+        debug('Not autojoining rooms because they already joined some', { token: this.loggableToken });
+      }
+    }.bind(this), AUTOJOIN_DELAY);
   }.bind(this))
   .catch(function(err) {
     log('Authentication failed for token ', token);
@@ -252,7 +261,7 @@ Adapter.prototype.joinRoom = function(room) {
   if (this.rooms[uri]) return;
 
   this.rooms[uri] = room;
-  
+
   room.users()
     .then(function(users) {
       var _channel = '#' + room.uri;

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -10,7 +10,7 @@ var VERSION    = manifest.version;
 var DATE       = Date();
 
 var MARK_AS_READ_DELAY = 1500;
-var AUTOJOIN_DELAY = 1000;
+var AUTOJOIN_DELAY = 2500;
 var AUTOJOIN_LIMIT = 10;
 
 // NOTE: whytf isn't this using debug?


### PR DESCRIPTION
Release/1.2.0

 - Disable autojoin if already joined rooms, https://github.com/gitterHQ/irc-bridge/pull/68
 - Ignore repeated JOIN attempts to a channel, https://github.com/gitterHQ/irc-bridge/pull/66