### PR TITLE
Cache room members - polling WHO

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var Promise = require('bluebird');
+
+function Cache(cacheDelegate) {
+  this.cacheDelegate = cacheDelegate;
+}
+
+Cache.prototype.get = function(key, fetchFn) {
+  return Promise.resolve(this.cacheDelegate.get(key, fetchFn));
+};
+
+module.exports = Cache;

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -1,9 +1,11 @@
 /* jshint unused:true, node:true */
 "use strict";
 
+var Promise    = require('bluebird');
 var debug      = require('debug')('irc-gitter-adapter');
-var irc        = require('./protocol');
+var LRU        = require('lru-cache');
 var Gitter     = require('node-gitter');
+var irc        = require('./protocol');
 var GitterRoom = require('node-gitter/lib/rooms');
 var manifest   = require('../package.json');
 var VERSION    = manifest.version;
@@ -26,6 +28,14 @@ function obfuscateToken(token) {
   token = token || '';
   return repeat('*', token.length - 8) + token.slice(token.length - 8);
 }
+
+var roomMemberCache = LRU({
+  max: 2048,
+  // 2 minutes
+  maxAge: 2 * 60 * 1000
+});
+
+
 
 function Adapter(client) {
   this.client = client;
@@ -296,6 +306,8 @@ Adapter.prototype.leaveRoom = function(channel) {
 };
 
 Adapter.prototype.listUsers = function(channel, key) {
+  var uri = channel.replace('#', '');
+
   var c = this.client;
 
   if (channel === undefined) {
@@ -306,12 +318,23 @@ Adapter.prototype.listUsers = function(channel, key) {
     c.send(c.mask(), 'WHO', ':' + channel);
     return;
   }
-  var uri = channel.replace('#', '');
 
-  this.gitterClient.rooms.join(uri)
-  .then(function(room) {
-    return room.users();
-  })
+  var getRoomMembers = Promise.method(function() {
+    var membersPromise = roomMemberCache.get(uri);
+    if (membersPromise) {
+      return membersPromise;
+    }
+    else {
+      return this.gitterClient.rooms.join(uri)
+      .then(function(room) {
+        var members = room.users();
+        roomMemberCache.set(uri, members);
+        return members;
+      });
+    }
+  }.bind(this));
+
+  getRoomMembers()
   .then(function(users) {
     users.forEach(function(user) {
       c.send(c.host, irc.reply.who, c.nick, channel, user.username, c.hostname, c.hostname, user.username, 'H', ':0', user.displayName);

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -18,7 +18,7 @@ var log = console.log;
 
 function repeat(c, n) {
   var s = '';
-  for (var i=0; i<n; i++) s = s+c;
+  for (var i = 0; i < n; i++) s += c;
   return s;
 }
 
@@ -39,16 +39,16 @@ function Adapter(client) {
 // Map IRC commands to adapter functions
 Adapter.prototype.hookEvents = function() {
   var commands = {
-    PASS:     this.setup,
-    PRIVMSG:  this.sendMessage,
-    QUIT:     this.quit,
-    NICK:     this.nick,
-    USER:     this.register,
-    JOIN:     this.joinChannels,
-    PART:     this.leaveRooms,
-    WHO:      this.listUsers,
-    LIST:     this.listRooms,
-    MOTD:     this.messageOfTheDay
+    PASS: this.setup,
+    PRIVMSG: this.sendMessage,
+    QUIT: this.quit,
+    NICK: this.nick,
+    USER: this.register,
+    JOIN: this.joinChannels,
+    PART: this.leaveRooms,
+    WHO: this.listUsers,
+    LIST: this.listRooms,
+    MOTD: this.messageOfTheDay
   };
 
   Object.keys(commands).map(function(cmd) {
@@ -108,7 +108,7 @@ Adapter.prototype.setup = function(token) {
   if (process.env.DEV) {
     opts = {
       client: {
-        host: "localhost",
+        host: 'localhost',
         port: 5000,
         prefix: true
       },
@@ -155,7 +155,7 @@ Adapter.prototype.subscribeToRoom = function(room) {
   room.subscribe();
 
   room.on('chatMessages', function(evt) {
-    if (['create','update'].indexOf(evt.operation) === -1) return;
+    if (['create', 'update'].indexOf(evt.operation) === -1) return;
 
     var message = evt.model;
     var nick = message.fromUser.username;
@@ -204,7 +204,7 @@ Adapter.prototype.subscribeToRoom = function(room) {
 
 Adapter.prototype.sendMessage = function(target, message) {
   var c = this.client;
-  var uri = target.replace('#','');
+  var uri = target.replace('#', '');
   var isStatus = /^\u0001ACTION/.test(message);
 
   // This are /me IRC messages.
@@ -244,7 +244,7 @@ Adapter.prototype.joinChannels = function(channels, key) {
 
 Adapter.prototype.joinRoomFromChannel = function(channel) {
   var c = this.client;
-  var uri = channel.replace('#','');
+  var uri = channel.replace('#', '');
 
   this.gitterClient.rooms.join(uri)
     .then(function(room) {
@@ -290,7 +290,7 @@ Adapter.prototype.leaveRooms = function(channels, key) {
 };
 
 Adapter.prototype.leaveRoom = function(channel) {
-  var uri = channel.replace('#','').toLowerCase();
+  var uri = channel.replace('#', '').toLowerCase();
   this.client.send(this.client.mask(), 'PART', channel);
   this._unsubscribe(uri);
 };
@@ -306,7 +306,7 @@ Adapter.prototype.listUsers = function(channel, key) {
     c.send(c.mask(), 'WHO', ':' + channel);
     return;
   }
-  var uri = channel.replace('#','');
+  var uri = channel.replace('#', '');
 
   this.gitterClient.rooms.join(uri)
   .then(function(room) {

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -306,7 +306,7 @@ Adapter.prototype.leaveRoom = function(channel) {
 };
 
 Adapter.prototype.listUsers = function(channel, key) {
-  var uri = channel.replace('#', '');
+  var uri = channel && channel.replace('#', '');
 
   var c = this.client;
 

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -329,11 +329,10 @@ Adapter.prototype.listUsers = function(channel, key) {
       var members = room.users();
       return members;
     });
-  });
+  }.bind(this));
 
-  getRoomMembers()
-  .then(function(users) {
-    users.forEach(function(user) {
+  getRoomMembers.then(function(users) {
+    (users || []).forEach(function(user) {
       c.send(c.host, irc.reply.who, c.nick, channel, user.username, c.hostname, c.hostname, user.username, 'H', ':0', user.displayName);
     });
     c.send(c.host, irc.reply.who, c.nick, channel, 'gitter', c.hostname, c.hostname, 'gitter', 'H', ':0', 'Gitter Bot');

--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -3,8 +3,9 @@
 
 var Promise    = require('bluebird');
 var debug      = require('debug')('irc-gitter-adapter');
-var LRU        = require('lru-cache');
 var Gitter     = require('node-gitter');
+var Cache      = require('./cache');
+var LruCacheDelegate = require('./lru-cache-delegate');
 var irc        = require('./protocol');
 var GitterRoom = require('node-gitter/lib/rooms');
 var manifest   = require('../package.json');
@@ -29,12 +30,14 @@ function obfuscateToken(token) {
   return repeat('*', token.length - 8) + token.slice(token.length - 8);
 }
 
-var roomMemberCache = LRU({
+
+var cacheDelegate = new LruCacheDelegate({
   max: 2048,
   // 2 minutes
   maxAge: 2 * 60 * 1000
 });
 
+var cache = new Cache(cacheDelegate);
 
 
 function Adapter(client) {
@@ -319,20 +322,14 @@ Adapter.prototype.listUsers = function(channel, key) {
     return;
   }
 
-  var getRoomMembers = Promise.method(function() {
-    var membersPromise = roomMemberCache.get(uri);
-    if (membersPromise) {
-      return membersPromise;
-    }
-    else {
-      return this.gitterClient.rooms.join(uri)
-      .then(function(room) {
-        var members = room.users();
-        roomMemberCache.set(uri, members);
-        return members;
-      });
-    }
-  }.bind(this));
+
+  var getRoomMembers = cache.get(uri, function() {
+    return this.gitterClient.rooms.join(uri)
+    .then(function(room) {
+      var members = room.users();
+      return members;
+    });
+  });
 
   getRoomMembers()
   .then(function(users) {

--- a/lib/lru-cache-delegate.js
+++ b/lib/lru-cache-delegate.js
@@ -11,11 +11,15 @@ LruCacheDelegate.prototype.get = Promise.method(function(key, fetchFn) {
   var val = this.backingCache.get(key);
 
   if(!val) {
-    return fetchFn()
+    return Promise.resolve(fetchFn())
+    .bind(this)
     .then(function(newVal) {
       this.backingCache.set(key, newVal);
-    }.bind(this));
+      return newVal;
+    });
   }
+
+  return Promise.resolve(val);
 });
 
 module.exports = LruCacheDelegate;

--- a/lib/lru-cache-delegate.js
+++ b/lib/lru-cache-delegate.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var Promise = require('bluebird');
+var LRU = require('lru-cache');
+
+function LruCacheDelegate(options) {
+  this.backingCache = LRU(options);
+}
+
+LruCacheDelegate.prototype.get = Promise.method(function(key, fetchFn) {
+  var val = this.backingCache.get(key);
+
+  if(!val) {
+    return fetchFn()
+    .then(function(newVal) {
+      this.backingCache.set(key, newVal);
+    }.bind(this));
+  }
+});
+
+module.exports = LruCacheDelegate;

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
   "author": "The Gitter Team",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.4.1",
     "carrier": "^0.1.14",
     "debug": "^2.1.1",
     "eventemitter3": "^0.1.6",
     "express": "^4.12.0",
     "irc-message": "^2.0.1",
     "jade": "^1.9.2",
+    "lru-cache": "^4.0.1",
     "node-gitter": "^2.0.4",
     "uuid": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "irc-message": "^2.0.1",
     "jade": "^1.9.2",
     "lru-cache": "^4.0.1",
-    "node-gitter": "^2.0.4",
+    "node-gitter": "^2.0.5",
     "uuid": "^2.0.1"
   },
   "devDependencies": {

--- a/test/cache_test.js
+++ b/test/cache_test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var assert = require('assert');
+var Promise = require('bluebird');
+var Cache = require('../lib/cache');
+
+
+
+describe('Cache', function() {
+
+  describe('static map', function() {
+    var cache;
+    var backingStore;
+    beforeEach(function() {
+      backingStore = {
+        foo: 'bar',
+        ping: 'pong'
+      };
+      var staticMapCacheDelegate = {
+        get: function(key, fetchFn) {
+          return Promise.resolve(backingStore[key]);
+        }
+      };
+
+      cache = new Cache(staticMapCacheDelegate);
+    });
+
+    it('should retrieve value from `.get`', function() {
+      var retrieveValuePromise = cache.get('foo', function() { });
+
+      return retrieveValuePromise
+        .then(function(val) {
+          assert.equal(val, 'bar');
+        });
+    });
+  });
+
+  describe('local map', function() {
+    var cache;
+    var backingStore;
+    beforeEach(function() {
+      backingStore = {};
+      var localMapCacheDelegate = {
+        get: function(key, fetchFn) {
+          return Promise.resolve(backingStore[key] || fetchFn().then(function(newVal) {
+            backingStore[key] = newVal;
+            return newVal;
+          }));
+        }
+      };
+
+      cache = new Cache(localMapCacheDelegate);
+    });
+
+    it('should fill in cache from fetchFn when empty', function() {
+      var expectedValue = 'bar';
+      var retrieveValuePromise = cache.get('foo', function() {
+        return Promise.resolve(expectedValue);
+      });
+
+      assert.deepEqual(backingStore, { });
+      return retrieveValuePromise
+        .then(function(val) {
+          assert.equal(val, expectedValue);
+          assert.deepEqual(backingStore, { foo: 'bar' });
+        });
+    });
+
+    it('should retrieve same value from cache', function() {
+      var expectedValue = 'bar';
+      var retrieveValuePromise = cache.get('foo', function() {
+        return Promise.resolve(expectedValue);
+      });
+
+      return retrieveValuePromise
+        .then(function(val) {
+          assert.equal(val, expectedValue);
+          assert.deepEqual(backingStore, { foo: 'bar' });
+        })
+        .then(function() {
+          return cache.get('foo', function() {
+            return Promise.resolve('oops');
+          });
+        })
+        .then(function(val) {
+          assert.equal(val, expectedValue);
+          assert.deepEqual(backingStore, { foo: 'bar' });
+        });
+    });
+  });
+});


### PR DESCRIPTION
Cache room members so that we don't hit the API rate limit for clients that poll the `WHO` command.

For example, HexChat polls every 30 seconds: https://github.com/hexchat/hexchat/blob/6b2cc1d28b67dd352c4be775ba214ca864cc5500/src/common/hexchat.c#L305

---


#### Todo

 - [ ] Add test to spy on `fetchFn` and see if only called when cache is dry
 - [x] Add manual `set` method
   - not needed