### PR TITLE
stop spamming me with "servers stopping" messages

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -59,7 +59,7 @@ Server.prototype.stop = function(cb) {
 
   // Disconnect all clients gracefully
   Object.keys(this.clients).map(function(uuid) {
-    this.clients[uuid].disconnect({msg: 'Server stopping.'});
+    this.clients[uuid].disconnect();
   }.bind(this));
 };
 


### PR DESCRIPTION
it's highly unusual for IRC servers to send a `PRIVMSG` to *every* user connected when it shuts down... at *most* there will be a `WALLOP` warning people of the reason behind the operation, and that's less intrusive: it's usually bound to a specific window and won't bring as much attention as a direct message.

i don't quite care if the server stops. i will notice through usual means, which is a warning in my status window. since i'm connected to the IRC bridge, I'm seeing this message about once a day, and it's pretty annoying.

i don't know if this will resolve it, I haven't tested this. but i hope it will.