### PR TITLE
Change disconnect msg protocol to more appropriate

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -159,8 +159,7 @@ Client.prototype.disconnect = function(opts) {
 
   if (opts.msg) {
     try {
-      var mask = ':gitter!gitter@irc.gitter.im';
-      this.send(mask, 'PRIVMSG', this.nick, ': ' + opts.msg);
+      this.send(this.host, 'NOTICE', this.nick, ': ' + opts.msg);
     }
     catch(err) {
       debug('Socket was already closed');


### PR DESCRIPTION
1. NOTICE is more appropriate than PRIVMSG: the user shouldn't respond to this ([see IRC RFC](https://en.wikipedia.org/wiki/List_of_Internet_Relay_Chat_commands#NOTICE)) and on an actual client PRIVMSG opens a new window etc.
2. Change the sender from "gitter" (ostensible a client/service) to this.host (= the server itself)