### PR TITLE
Add a response to the VERSION command

### DIFF
--- a/lib/gitter-adapter.js
+++ b/lib/gitter-adapter.js
@@ -61,7 +61,8 @@ Adapter.prototype.hookEvents = function() {
     PART: this.leaveRooms,
     WHO: this.listUsers,
     LIST: this.listRooms,
-    MOTD: this.messageOfTheDay
+    MOTD: this.messageOfTheDay,
+    VERSION: this.version,
   };
 
   Object.keys(commands).map(function(cmd) {
@@ -254,10 +255,21 @@ Adapter.prototype.register = function(username, hostname, servername, realname) 
   c.send(c.host, irc.reply.welcome, c.nick, 'Gitter', c.mask());
   c.send(c.host, irc.reply.yourHost, c.nick, 'Version:', VERSION);
   c.send(c.host, irc.reply.created, c.nick, 'Created on', DATE);
-  c.send(c.host, irc.reply.myInfo, c.nick, c.hostname, VERSION, 'wo', 'ntr');
-  c.send(c.host, irc.reply.isupport, c.nick, 'CHANTYPES=# CHANMODES=,,, CHANNELLEN=128 NICKLEN=40 NETWORK=Gitter SAFELIST CASEMAPPING=ascii :are supported by this server');
+  c.send(c.host, irc.reply.myInfo, c.nick, c.hostname, "gitter-irc-bridge-" + VERSION, 'wo', 'ntr');
+  this.isupport();
   this.messageOfTheDay();
 };
+
+Adapter.prototype.isupport = function() {
+  var c = this.client;
+  c.send(c.host, irc.reply.isupport, c.nick, 'CHANTYPES=# CHANMODES=,,, CHANNELLEN=128 NICKLEN=40 NETWORK=Gitter SAFELIST CASEMAPPING=ascii :are supported by this server');
+}
+
+Adapter.prototype.version = function() {
+  var c = this.client;
+  c.send(c.host, irc.reply.version, c.nick, "gitter-irc-bridge-" + VERSION, c.hostname, ':')
+  this.isupport();
+}
 
 Adapter.prototype.joinChannels = function(channels, key) {
   if (channels) channels.split(',').map(this.joinRoomFromChannel.bind(this));


### PR DESCRIPTION
Numeric 351, followed by 005

This also changes the version string in numeric 004 to be prefixed by "gitter-irc-bridge-" for consistency

Gitter response:

```
:irc.gitter.im 351 dequis gitter-irc-bridge-1.4.0 irc.gitter.im :
:irc.gitter.im 005 dequis CHANTYPES=# CHANMODES=,,, CHANNELLEN=128 NICKLEN=40 NETWORK=Gitter SAFELIST CASEMAPPING=ascii :are supported by this server
```

Freenode response, for reference:

```
:barjavel.freenode.net 351 dx ircd-seven-1.1.4(20170104-717fbca8dbac,charybdis-3.4-dev). barjavel.freenode.net :eHIKMpSZ6 TS6ow 92A
:barjavel.freenode.net 005 dx CHANTYPES=# EXCEPTS INVEX CHANMODES=eIbq,k,flj,CFLMPQScgimnprstz CHANLIMIT=#:120 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 NETWORK=freenode STATUSMSG=@+ CALLERID=g CASEMAPPING=rfc1459 :are supported by this server
:barjavel.freenode.net 005 dx CHARSET=ascii NICKLEN=16 CHANNELLEN=50 TOPICLEN=390 DEAF=D FNC TARGMAX=NAMES:1,LIST:1,KICK:1,WHOIS:1,PRIVMSG:4,NOTICE:4,ACCEPT:,MONITOR: EXTBAN=$,ajrxz CLIENTVER=3.0 SAFELIST ELIST=CTU WHOX :are supported by this server
:barjavel.freenode.net 005 dx ETRACE CPRIVMSG CNOTICE KNOCK :are supported by this server
```

Docs: [modern](http://modern.ircdocs.horse/#version-message), [defs](http://defs.ircdocs.horse/defs/ircnumerics.html#rpl-version-351), [rfc1459 (command)](https://tools.ietf.org/html/rfc1459#section-4.3.1), [rfc1459 (numeric)](https://tools.ietf.org/html/rfc1459#page-50)