### PR TITLE
Send PONG replies using the parameter sent from the client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -66,8 +66,8 @@ Client.prototype.keepAlive = function() {
     this.send('PING', this.host);
   };
 
-  var pong = function() {
-    this.send('PONG', this.host);
+  var pong = function(param) {
+    this.send(this.host, 'PONG', this.hostname, ':' + (param ? param : this.host));
   };
 
   var refreshConnectionTimeout = function() {


### PR DESCRIPTION
Fixes issues with clients like hexchat not being able to correlate sent pings and displaying them as noise in the server buffer.

```
  irc-client Rx: PING irc.gitter.im +9s
  irc-client Tx: :irc.gitter.im PONG irc.gitter.im :irc.gitter.im +0ms
  irc-client Rx: PING LAG1489229945904 +19s
  irc-client Tx: :irc.gitter.im PONG irc.gitter.im :LAG1489229945904 +0ms
```

[rfc1459](https://tools.ietf.org/html/rfc1459#section-4.6.2) (but as you can see above, in practice the server2 parameter isn't used as such)